### PR TITLE
Fix patch request intercept to utilize proper id

### DIFF
--- a/cypress/integration/error_handling_spec.js
+++ b/cypress/integration/error_handling_spec.js
@@ -2,7 +2,7 @@ describe('Referle Error Handling', () => {
   it('should be met with error modal if patch request is sent with invalid id', () => {
     cy.viewport('iphone-xr');
     cy.intercept('https://referle.herokuapp.com/api/v1/heuristics/sorted/avg_tile_score?page=1&limit=10', { fixture: 'defaultSortedGetResult' }).as('defaultGet');
-    cy.intercept('PATCH', 'https://referle.herokuapp.com/api/v1/heuristics/ffffff', {
+    cy.intercept('PATCH', 'https://referle.herokuapp.com/api/v1/heuristics/10364', {
       statusCode: 404,
     }).as('patchRequest');
 


### PR DESCRIPTION
## What Features are Being Added?
- Nothing


## What is Being Refactored?
- Refactored patch request in error handling spec to implement the proper id for the word card so the request would be intercepted correctly. 


## What Do You Need From Your Teammates?



## Any Other Notes/Questions/Problems?
